### PR TITLE
try fix permission issue in tdm error

### DIFF
--- a/.github/workflows/deploy-tdm.yml
+++ b/.github/workflows/deploy-tdm.yml
@@ -7,7 +7,7 @@
 # To get a newer version, you will need to update the SHA.
 # You can also reference a tag or branch, but the action may change without warning.
 
-name: Publish TDM Log Image and Update Helm Chart
+name: Publish TDM Docker Image and Update Helm Chart
 
 on:
   pull_request:

--- a/rda-tds/Dockerfile-tdm
+++ b/rda-tds/Dockerfile-tdm
@@ -1,6 +1,9 @@
 FROM unidata/tdm-docker:5.6
 COPY ./content/ /usr/local/tomcat/content/tdm/thredds/
 
+# correct permission issue on /data/TDSIndexFiles/data/rda/data
+RUN mkdir -p /data/TDSIndexFiles/data/rda/data
+RUN chmod 777 /data/TDSIndexFiles/data/rda/data
 
 # Source env file in helmchart?
     #env_file:


### PR DESCRIPTION
related to NetCDF-Java Common Data Model (CDM) library existing GRIB index files are corrupted or unreadable, and the system is simultaneously running into file permission issues when trying to fix them