### PR TITLE
Feature/update

### DIFF
--- a/rda-tds-helm/templates/deployment.yaml
+++ b/rda-tds-helm/templates/deployment.yaml
@@ -77,6 +77,9 @@ spec:
         - mountPath: /usr/local/tomcat/content/thredds/logs # TDS logs dir
           name: {{ .Values.webapp.volume.fs.name }}
           subPath: tds-temp-logs
+        - mountPath: /usr/local/tomcat/temp # TDS NCSS temp files
+          name: {{ .Values.webapp.volume.fs.name }}
+          subPath: tds-overflow/tomcat-temp # Tomcat temp files
         # - mountPath: /usr/local/tomcat/content/thredds
         #   name: {{ .Values.webapp.volume.fs.name }}
         #   subPath: thredds-content # Full thredds dir on PVC - refreshed on every restart by initContainer

--- a/rda-tds/conf/server.xml
+++ b/rda-tds/conf/server.xml
@@ -73,7 +73,8 @@
                scheme="https"
                secure="true"
                connectionTimeout="20000"
-               redirectPort="8443" >
+               redirectPort="8443"
+               maxThreads="100" >
     <!-- Riley -->
     <!--<Connector port="8443"
            maxThreads="150"

--- a/rda-tds/content/threddsConfig.xml
+++ b/rda-tds/content/threddsConfig.xml
@@ -150,6 +150,7 @@
     <allow>true</allow>
     <scour>30 min</scour>
     <maxAge>5 min</maxAge>
+    <maxFileDownloadSize>1 GB</maxFileDownloadSize>
   </NetcdfSubsetService>
 
    <FeatureCollection>

--- a/rda-tds/thredds/threddsConfig.xml
+++ b/rda-tds/thredds/threddsConfig.xml
@@ -150,6 +150,7 @@
     <allow>true</allow>
     <scour>30 min</scour>
     <maxAge>5 min</maxAge>
+    <maxFileDownloadSize>1 GB</maxFileDownloadSize>
   </NetcdfSubsetService>
 
    <FeatureCollection>


### PR DESCRIPTION
This pull request introduces configuration improvements to the deployment and operation of the TDS (THREDDS Data Server) application. The changes focus on enhancing resource management, increasing download limits, and fine-tuning Tomcat server settings.

**Deployment and resource management:**

* Added a new volume mount in `deployment.yaml` to store Tomcat temporary files at `/usr/local/tomcat/temp`, helping to manage overflow and temporary storage more effectively.

**TDS service configuration:**

* Setup maximum allowed file download size to 1 GB in both `content/threddsConfig.xml` and `thredds/threddsConfig.xml`

**Tomcat server tuning:**

* Set the `maxThreads` attribute to 100 for the main Tomcat HTTP connector in `conf/server.xml`, which can improve server performance under load by allowing more concurrent connections.