### PR TITLE
optimize Tomcat limits and PVC mount 

### DIFF
--- a/rda-tds-helm/templates/deployment.yaml
+++ b/rda-tds-helm/templates/deployment.yaml
@@ -74,12 +74,18 @@ spec:
         - mountPath: /usr/local/tomcat/content/thredds/cache/cdm # TDS cache cdm dir
           name: {{ .Values.webapp.volume.fs.name }}
           subPath: tds-temp-cache-cdm
+        - mountPath: /usr/local/tomcat/content/thredds/cache/ncss # TDS cache ncss dir
+          name: {{ .Values.webapp.volume.fs.name }}
+          subPath: tds-temp-cache-ncss
         - mountPath: /usr/local/tomcat/content/thredds/logs # TDS logs dir
           name: {{ .Values.webapp.volume.fs.name }}
           subPath: tds-temp-logs
         - mountPath: /usr/local/tomcat/temp # TDS NCSS temp files
           name: {{ .Values.webapp.volume.fs.name }}
           subPath: tds-overflow/tomcat-temp # Tomcat temp files
+        - mountPath: /usr/local/tomcat/work # TDS NCSS temp files
+          name: {{ .Values.webapp.volume.fs.name }}
+          subPath: tds-overflow/tomcat-work # Tomcat temp files
         # - mountPath: /usr/local/tomcat/content/thredds
         #   name: {{ .Values.webapp.volume.fs.name }}
         #   subPath: thredds-content # Full thredds dir on PVC - refreshed on every restart by initContainer

--- a/rda-tds-helm/values.yaml
+++ b/rda-tds-helm/values.yaml
@@ -37,7 +37,7 @@ webapp:
     ephemeralStorageLimit: 1Gi
   tdm:
     name: gdex-tdm
-    image: docker.io/potatofever/gdex-tdm:sha-402d00b
+    image: docker.io/potatofever/gdex-tdm:sha-7f620b8
     port: 8080
     memory: 6G
     cpu: 2

--- a/rda-tds-helm/values.yaml
+++ b/rda-tds-helm/values.yaml
@@ -22,8 +22,8 @@ webapp:
     ephemeralStorageLimit: 5Gi
     responseTimeout: 180
     maxUploadSize: 30m
-    limit_connections: 100  # Increased for concurrent requests
-    limit_rps: 200          # Increased for page load bursts
+    limit_connections: 20  # Increased for concurrent requests
+    limit_rps: 50          # Increased for page load bursts
  
     env:
       THREDDS_XMX_SIZE: 32G

--- a/rda-tds-helm/values.yaml
+++ b/rda-tds-helm/values.yaml
@@ -15,7 +15,7 @@ webapp:
     secretName: incommon-cert-tds
   container: 
     load_balance: ewma  # Enable weighted load balancing to avoid traffic concentrate on a subset of pods 
-    image: docker.io/potatofever/rda-tds:sha-a7ebbed
+    image: docker.io/potatofever/rda-tds:sha-8fc9203
     port: 8080
     memory: 40G
     cpu: 5


### PR DESCRIPTION
This pull request updates the deployment configuration and resource limits for the RDA TDS Helm chart. The main changes include updating container images, adjusting connection and rate limits, and adding new persistent volume mounts for improved caching and temp file management.

**Resource and connection limit adjustments:**

* Reduced `limit_connections` from 100 to 20 and `limit_rps` from 200 to 50 for the `webapp` to better control resource usage and traffic bursts.

**Persistent volume improvements:**

* Added new volume mounts for `ncss` cache and `tomcat` work directory in the deployment YAML, improving cache and temp file handling.