### PR TITLE
Update service limits across various features

### DIFF
--- a/rda-tds-helm/values.yaml
+++ b/rda-tds-helm/values.yaml
@@ -22,8 +22,8 @@ webapp:
     ephemeralStorageLimit: 5Gi
     responseTimeout: 180
     maxUploadSize: 30m
-    limit_connections: 30  # Increased for concurrent requests
-    limit_rps: 60          # Increased for page load bursts
+    limit_connections: 50  # Increased for concurrent requests
+    limit_rps: 100         # Increased for page load bursts
  
     env:
       THREDDS_XMX_SIZE: 32G

--- a/rda-tds/content/threddsConfig.xml
+++ b/rda-tds/content/threddsConfig.xml
@@ -4,20 +4,20 @@
   <!-- all options are commented out in standard install - meaning use default values -->
   <!-- see http://www.unidata.ucar.edu/projects/THREDDS/tech/reference/ThreddsConfigXMLFile.html -->
   <serverInformation>
-    <name>NCAR GDEX TDS Installation</name>
+    <name>NCAR GDEX THREDDS Server</name>
     <logoUrl>/thredds/gdex-logo-header.png</logoUrl>
     <nsfLogo>/thredds/NCAR-Sponsored-NSF-White.png</nsfLogo>
     <installUrl>http://tds.gdex.ucar.edu/thredds/</installUrl>
-    <logoAltText>NCAR GDEX TDS Installation</logoAltText>
+    <logoAltText>NCAR GDEX THREDDS Server</logoAltText>
     <test>a test</test>
 
-    <abstract>Scientific Data</abstract>
+    <abstract>Geoscientific Data</abstract>
     <keywords>meteorology, atmosphere, climate, ocean, earth science</keywords>
     
     <contact>
       <name>Support</name>
       <organization>NCAR GDEX</organization>
-      <email>rpconroy@ucar.edu</email>
+      <email>chiaweih@ucar.edu</email>
       <!--phone></phone-->
     </contact>
     <hostInstitution>
@@ -109,26 +109,27 @@
   </RandomAccessFile>
 
   <GribCollection>
-    <minFiles>9500</minFiles>
-    <maxFiles>10000</maxFiles>
+    <minFiles>100</minFiles>
+    <maxFiles>200</maxFiles>
     <scour>5 min</scour>
   </GribCollection>
   <TimePartition>
-    <minFiles>9500</minFiles>
-    <maxFiles>10000</maxFiles>
+    <minFiles>100</minFiles>
+    <maxFiles>200</maxFiles>
     <scour>5 min</scour>
   </TimePartition>
+  
 
 
   <!--
   The <HTTPFileCache> element:
-  allow 10 - 20 open datasets, cleanup every 17 minutes
+  allow 10 - 20 open datasets, cleanup every 5 minutes
   used by HTTP Range requests.
   -->
   <HTTPFileCache>
-    <minFiles>10</minFiles>
-    <maxFiles>20</maxFiles>
-    <scour>17 min</scour>
+    <minFiles>5</minFiles>
+    <maxFiles>10</maxFiles>
+    <scour>5 min</scour>
   </HTTPFileCache>
  
 
@@ -148,9 +149,9 @@
   -->
   <NetcdfSubsetService>
     <allow>true</allow>
-    <scour>30 min</scour>
+    <scour>15 min</scour>
     <maxAge>5 min</maxAge>
-    <maxFileDownloadSize>1 GB</maxFileDownloadSize>
+    <maxFileDownloadSize>500 MB</maxFileDownloadSize>
   </NetcdfSubsetService>
 
    <FeatureCollection>
@@ -170,7 +171,7 @@
     <allow>true</allow>
     <allowRemote>false</allowRemote>
     <scour>15 min</scour>
-    <maxAge>30 min</maxAge>
+    <maxAge>5 min</maxAge>
   </WCS>
 
 


### PR DESCRIPTION
This pull request updates the configuration for the THREDDS Data Server (TDS), focusing on improving performance, tightening resource usage, and updating server metadata. The main changes involve increasing connection and request limits for the webapp, refining cache and file handling parameters for more efficient resource management, and updating server information and contact details.

**Resource and Performance Tuning:**

* Increased `limit_connections` from 30 to 50 and `limit_rps` (requests per second) from 60 to 100 in the `webapp` section of `values.yaml` to support higher concurrency and burst traffic.
* Reduced file cache and collection parameters in `threddsConfig.xml`:
  - Lowered `minFiles`/`maxFiles` for `GribCollection` and `TimePartition` from 9500–10000 to 100–200.
  - Decreased `HTTPFileCache` from 10–20 files (scour every 17 min) to 5–10 files (scour every 5 min).

**Service Limits and Cleanup Intervals:**

* Shortened `scour` intervals and reduced maximum file download size:
  - `NetcdfSubsetService`: `scour` from 30 to 15 min, `maxFileDownloadSize` from 1 GB to 500 MB.
  - [`WCS`](diffhunk://#diff-8f3925d0a9783e2a90a5291c548679ececadcfea4dc41f18739af4d46e5e4aebL151-R154): `maxAge` from 30 to 5 min. [[1]](diffhunk://#diff-8f3925d0a9783e2a90a5291c548679ececadcfea4dc41f18739af4d46e5e4aebL151-R154) [[2]](diffhunk://#diff-8f3925d0a9783e2a90a5291c548679ececadcfea4dc41f18739af4d46e5e4aebL173-R174)

**Server Metadata Updates:**

* Updated server name, logo alt text, abstract, and contact email in `threddsConfig.xml` to reflect new branding and support contact.