### PR TITLE
Center h4 and reorganize footer message, update header height

### DIFF
--- a/rda-tds/content/public/tds.css
+++ b/rda-tds/content/public/tds.css
@@ -233,7 +233,7 @@ div#header, div#footer {
 
 
 div#header {
-    height:90px;
+    height:110px;
     top: 0px;
     margin-bottom: 8px;
 }
@@ -300,7 +300,7 @@ div.container {
     width: 100%;
     position: relative;
     padding: 30px 50px;
-    padding-top: 98px;   /* header height (90px) + margin-bottom (8px) */
+    padding-top: 118px;   /* header height (110px) + margin-bottom (8px) */
     padding-bottom: 150px; /* footer height */
     box-sizing: border-box;
 }

--- a/rda-tds/content/templates/tdsTemplateFragments.html
+++ b/rda-tds/content/templates/tdsTemplateFragments.html
@@ -29,24 +29,27 @@
     </div>
 </div>
 <div th:fragment="footer">
-<h4>
-    <a class="static" th:href="${installUrl}" th:text="${installName}"></a> 
-    at 
-    <a class="static" th:href="${hostInstUrl}" th:text="${hostInst}"></a> 
-    see 
-    <a class="static" th:href="${contextPath} + '/info/serverInfo.html'"> Info </a>
-</h4>
-<h4>
-    <a class="static" th:href="${webappUrl}" th:text="${webappName}"></a>
-    <th:block th:text="' [Version ' + ${webappVersion} + ' - ' + ${webappBuildTimestamp} + ']'"/>
-    <a class="static" th:href="${webappDocsUrl}"> Documentation</a>
-</h4>
+
 <div class="footer-message" style='color:black'>
-The Geoscience Data Exchange is managed by the Data Engineering and Curation Group of the Computational and Information Systems Laboratory at the National Center for Atmospheric Research in Boulder, Colorado. The National Center for Atmospheric Research is sponsored by the National Science Foundation. Any opinions, findings, and conclusions or recommendations expressed in this material do not necessarily reflect the views of the National Science Foundation.
+    <h4>
+        <a class="static" th:href="${installUrl}" th:text="${installName}"></a> 
+        at 
+        <a class="static" th:href="${hostInstUrl}" th:text="${hostInst}"></a> 
+        see 
+        <a class="static" th:href="${contextPath} + '/info/serverInfo.html'"> Info </a>
+    </h4>
+    <h4>
+        <a class="static" th:href="${webappUrl}" th:text="${webappName}"></a>
+        <th:block th:text="' [Version ' + ${webappVersion} + ' - ' + ${webappBuildTimestamp} + ']'"/>
+        <a class="static" th:href="${webappDocsUrl}"> Documentation</a>
+    </h4>
+    <p>
+        The Geoscience Data Exchange is managed by the Data Engineering and Curation Group of the Computational and Information Systems Laboratory at the National Center for Atmospheric Research in Boulder, Colorado.
+        The National Center for Atmospheric Research is sponsored by the National Science Foundation. 
+        Any opinions, findings, and conclusions or recommendations expressed in this material do not necessarily reflect the views of the National Science Foundation.
+    </p>
+
 </div>
-       
-
-
        
 </div>
 


### PR DESCRIPTION
This pull request updates the site layout to accommodate a taller header and improves the footer's structure and accessibility. The most important changes are:

**Layout adjustments:**

* Increased the header height in `tds.css` from 90px to 110px (`div#header`) and updated the corresponding top padding in `div.container` to 118px to ensure content is properly positioned below the larger header. [[1]](diffhunk://#diff-213aecb954b15d2591c62f9a5cf5ab9f2c92f925d77db81849dcdeee9ad857ffL236-R236) [[2]](diffhunk://#diff-213aecb954b15d2591c62f9a5cf5ab9f2c92f925d77db81849dcdeee9ad857ffL303-R303)

**Footer improvements:**

* Refactored the footer in `tdsTemplateFragments.html` by wrapping the footer message in a `<p>` tag for better semantic structure and accessibility, and moved the `.footer-message` div to ensure correct HTML nesting. [[1]](diffhunk://#diff-139e5ebd93eba5ce1569f79720378a07db405a8a634dec062d663e740c807915R32-R33) [[2]](diffhunk://#diff-139e5ebd93eba5ce1569f79720378a07db405a8a634dec062d663e740c807915L44-R52)