### PR TITLE
fix bug in byte parsing

### DIFF
--- a/rda-tds-helm/scripts/log_stats.py
+++ b/rda-tds-helm/scripts/log_stats.py
@@ -42,7 +42,7 @@ for log_file in log_files:
             if status != "200":
                 failed_requests += 1
             else:
-                bytes_success += int(bytes_raw)
+                bytes_success += int(bytes_raw) if bytes_raw != "-" else 0
             bytes_sent += int(bytes_raw) if bytes_raw != "-" else 0
 
             # check access patterns


### PR DESCRIPTION
This pull request makes a minor improvement to the way log statistics are calculated in `log_stats.py`. The change ensures that when the `bytes_raw` field is "-", it is treated as zero rather than causing a potential error during integer conversion.