### PR TITLE
Create test pod setup

### DIFF
--- a/rda-tds-helm/test-pod-writable.yaml
+++ b/rda-tds-helm/test-pod-writable.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: log-stats-report-test
+  namespace: rda
+spec:
+  initContainers:
+  - name: init-script
+    image: python:3.11-slim
+    command: ["/bin/sh", "-c", "cp /configmap-scripts/log_stats.py /scripts/log_stats.py"]
+    volumeMounts:
+    - mountPath: /configmap-scripts
+      name: configmap-volume
+    - mountPath: /scripts
+      name: script-volume
+  containers:
+  - name: log-stats
+    image: python:3.11-slim
+    command: ["/bin/sh", "-c", "apt-get update -qq && apt-get install -y vim && sleep infinity"]
+    volumeMounts:
+    - mountPath: /usr/local/tomcat/logs
+      name: logs-volume
+    - mountPath: /scripts
+      name: script-volume
+  volumes:
+  - name: logs-volume
+    persistentVolumeClaim:
+      claimName: logs-persist
+  - name: configmap-volume
+    configMap:
+      name: log-stats-script
+  - name: script-volume
+    emptyDir: {}
+  restartPolicy: Never


### PR DESCRIPTION
This pull request adds a new Kubernetes pod specification for testing purposes. The new manifest defines a pod with an init container to copy a script from a config map and a main container for log analysis tasks, including necessary volume mounts for logs and scripts.

Pod specification for log analysis testing:

* Added `rda-tds-helm/test-pod-writable.yaml` with a pod definition that includes:
  - An init container to copy `log_stats.py` from a config map to a writable scripts directory.
  - A main container running Python 3.11 with Vim installed and access to persistent log and script volumes.
  - Volume mounts for logs, scripts, and the config map, supporting log analysis workflows.