### PR TITLE
add badge for health check quick view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GDEX TDS — Deployment & Operations Guide
 
+[![TDS Health Check](https://github.com/NCAR/gdex-tds/actions/workflows/tds-health-check.yml/badge.svg)](https://github.com/NCAR/gdex-tds/actions/workflows/tds-health-check.yml)
+
 ## Overview
 
 GDEX TDS (THREDDS Data Server) is deployed on NCAR's CIRRUS Kubernetes cluster. This repo contains:


### PR DESCRIPTION
This pull request adds a status badge to the `README.md` to display the health of the TDS service. This helps users quickly see the current status of the TDS Health Check workflow.

* Added a TDS Health Check status badge to the top of the `README.md` file.